### PR TITLE
feat(functions): Implement generic path in paths variable test

### DIFF
--- a/functions.sh.source
+++ b/functions.sh.source
@@ -100,5 +100,51 @@ install_executable_search_path(){
     return 0
 }
 
+# Check if the dir is already in paths
+#
+# Positional parameters:
+#
+# 1. dir: Directory to check existence
+# 2. paths: The PATHs variable to check
+#
+# Return values:
+#
+# * 0: `dir` exists in `paths`
+# * 1: `dir` not exist in `paths`
+# * 2: Error occurred
+is_dir_in_paths(){
+    if test "${#}" -ne 2; then
+        printf \
+            'is_dir_in_paths: Error: This function should have 2 arguments, only %s is specified.\n' \
+            "${#}" \
+            1>&2
+        return 2
+    fi
+
+    dir="${1}"; shift
+    paths="${1}"; shift
+
+    # Backup IFS
+    IFS_ORIGINAL="${IFS}"
+    IFS=":"
+
+    path_found=false
+    for path in ${paths}; do
+        if [ "${dir}" = "${path}" ]; then
+            path_found=true
+            break
+        fi
+    done
+
+    # Restore IFS
+    IFS="${IFS_ORIGINAL}"
+
+    if test "${path_found}" = false; then
+        return 1
+    else
+        return 0
+    fi
+}
+
 ## Set include guard
 readonly _PROFILE_D_FUNCTIONS_INCLUDED="1"


### PR DESCRIPTION
Essentially `is_dir_in_executable_search_path` but can check environment variables other than `PATH`.

(e.g. `XDG_DATA_DIRS`)

Fixes #10.