### PR TITLE
fix(setup): Fix error printed when no scriptlets are installed

### DIFF
--- a/setup.sh.source
+++ b/setup.sh.source
@@ -21,6 +21,10 @@ if [ -z "${_PROFILE_D_SOURCED}" ]; then
     # Source every profile script in ~/.profile.d
     if [ -d "${HOME}/.profile.d" ]; then
         for script_source in "${HOME}/.profile.d"/*.source.sh; do
+            if test "${script_source}" = "${HOME}/.profile.d/*.source.sh"; then
+                break
+            fi
+
             script_source_filename="${script_source##*/}"
             if test "${script_source_filename}" == functions.sh.source \
                 || test "${script_source_filename}" == setup.sh.source; then


### PR DESCRIPTION
In POSIX sh the filename expansion pattern will literally expand to itself when no files are matched, ensure we skip the logic when this situation occurred.

Fixes #9.